### PR TITLE
Type hinting on withErrors to only accept MessageBag

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Http;
 
 use Illuminate\Session\Store as SessionStore;
+use Illuminate\Support\MessageBag;
 
 class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectResponse {
 
@@ -44,7 +45,7 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	 * @param  mixed  $errors
 	 * @return void
 	 */
-	public function withErrors($errors)
+	public function withErrors(MessageBag $errors)
 	{
 		$this->with('errors', $errors);
 


### PR DESCRIPTION
withErrors() should be reserved for using the MessageBag
implementation, be it from a Validator or creating a MessageBag
