### PR TITLE
Make Input::json() more logical

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -379,15 +379,21 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	/**
 	 * Get the JSON payload for the request.
 	 *
-	 * @return object
+	 * @param  string  $key
+	 * @param  mixed   $default
+	 * @return string
 	 */
-	public function json()
+	public function json($key = null, $default = null)
 	{
-		$arguments = func_get_args();
+		$mime = $this->retrieveItem('server', 'CONTENT_TYPE', null);
 
-		array_unshift($arguments, $this->getContent());
+		if (strpos($mime, '/json') === false) {
+			return $default;
+		}
+		
+		$json = json_decode($this->getContent(), true);
 
-		return call_user_func_array('json_decode', $arguments);
+		return array_get($json, $key, $default);
 	}
 
 	/**


### PR DESCRIPTION
Now you can send JSON payloads as an actual body in a PUT or POST request, instead of only decoding a specific POST param, or whatever it was doing before.

Also, if a non-JSON mime-type is sent it will refuse to try and parse the data, instead only returning the default value. This to me seems like a much more logical usage of Input::json() than the initial implementation.
