### PR TITLE
File upload is broken when submitting a form without selecting a file.

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -599,16 +599,16 @@ class Request extends SymfonyRequest {
 	{
 		if ($request instanceof static) return $request;
 
-		$files = [];
-		foreach ($request->files->all() as $index => $file) {
-			if (null !== $file) $files[$index] = $file;
-		}
+		$files = array_filter($request->files->all(), function($file)
+		{
+			return $file !== null;
+		});
 
 		return (new static)->duplicate(
 
-    			$request->query->all(), $request->request->all(), $request->attributes->all(),
+			$request->query->all(), $request->request->all(), $request->attributes->all(),
 
-    			$request->cookies->all(), $files, $request->server->all()
+			$request->cookies->all(), $files, $request->server->all()
 		);
 		
 	}


### PR DESCRIPTION
File upload is broken when submitting a form without selecting a file in Laravel 5! My tests revealed that with this tweek the problem described at this issue are resolved: https://github.com/laravel/framework/issues/6189

Credits to @Marwelln

This resolves a problem that occours in Symfony on the FileBag.php file, convertFileInformation() method. It receaves a empty array file and than returns NULL, if no files was selected on the upload. In this case "FileBag->set('image', NULL)" receives NULL, and that is what is dispatching a throw in Symfony.

I misunderstood the problem, and try attempt to do a pull request on symfony, but it was denied: https://github.com/symfony/symfony/pull/12486

I don't make unit tests, but this will no more break my code flow. I'm not sure if this is the real deal! If someone could look deeper into the problem, I appreciated!
