### PR TITLE
add content-length to header

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -25,6 +25,7 @@ class Response extends BaseResponse
     public function setContent($content)
     {
         $this->original = $content;
+        $this->header('Content-Length', strlen($content));
 
         // If the content is "JSONable" we will set the appropriate header and convert
         // the content to JSON. This is useful when returning something like models


### PR DESCRIPTION
https://github.com/laravel/framework/issues/29227
I added the content length to the header, cause on head request it can not be identified by the web server.
