### PR TITLE
Fix 'strstr' function usage based on its signature

### DIFF
--- a/Concerns/InteractsWithInput.php
+++ b/Concerns/InteractsWithInput.php
@@ -60,7 +60,7 @@ trait InteractsWithInput
         if ($position !== false) {
             $header = substr($header, $position + 7);
 
-            return str_contains($header, ',') ? strstr(',', $header, true) : $header;
+            return str_contains($header, ',') ? strstr($header, ',', true) : $header;
         }
     }
 


### PR DESCRIPTION
Fixed invalid usage of `strstr` function of php in `InteractsWithInput` trait.
Here is the reference for the `strstr` function usage:
https://www.php.net/manual/en/function.strstr.php