### PR TITLE
Restore lost logic

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -446,6 +446,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public static function createFromBase(SymfonyRequest $request)
     {
+	if ($request instanceof static) {
+		return $request;
+	}
+
         $newRequest = (new static)->duplicate(
             $request->query->all(), $request->request->all(), $request->attributes->all(),
             $request->cookies->all(), $request->files->all(), $request->server->all()


### PR DESCRIPTION
See: https://github.com/illuminate/http/commit/7bd8edddd41c4df3c0b953afbdf4472b1183954f

This was removed for no obvious reason.

This has generated a problem whereby a request that is provided will lose its `JSON` content when returned.

Was working before:

```php
$request = Request::create('...','..');
$request->setJson(new ParameterBag(['....]));
app()->handle($request);
```

In target controller you could use `$request->input()` to read the JSON contents.
Without these lines of code, the `input` is empty and JSON is not present.

The workaround we use currently is:

```php
$request = Request::create('...','..');
$request->setJson(new ParameterBag(['....]));
app(\App\Http\Kernel::class)->handle($request);
```

But in fairness, the request class should learn how to pass over the JSON contents in the first place.