### PR TITLE
Method added: Response::throwUnless

### DIFF
--- a/Client/Response.php
+++ b/Client/Response.php
@@ -326,6 +326,19 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Throw an exception if a server or client error occurred and the given condition evaluates to false.
+     *
+     * @param  bool  $condition
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwUnless($condition)
+    {
+        return $this->throwIf(! $condition);
+    }
+
+    /**
      * Determine if the given offset exists.
      *
      * @param  string  $offset


### PR DESCRIPTION
Documentation includes `throwUnless` method on the **Response** class but the method does not exist.

![image](https://user-images.githubusercontent.com/2676602/186453554-4a082ad6-e354-4999-8498-bf6e07163c09.png)
